### PR TITLE
Add testing workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,17 @@
+name: Action test
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Deploy to GCP
+      uses: ./
+      with:
+        service-key: test-service-key
+        project: test-project
+        bucket-name: test-bucket-name


### PR DESCRIPTION
Right now this should always fail, since no GCS bucket is properly set
up for it.